### PR TITLE
Update gt9xx_main.c

### DIFF
--- a/drivers/input/touchscreen/gt927/gt9xx_main.c
+++ b/drivers/input/touchscreen/gt927/gt9xx_main.c
@@ -1286,7 +1286,7 @@ static int goodix_ts_probe(struct i2c_client *client, const struct i2c_device_id
     }
 
 config_info.dev = &(ts->input_dev->dev);
-	ret = input_request_int(&(config_info.input_type), goodix_ts_irq_handler,CTP_IRQ_MODE, ts);	   
+	ret = input_request_int(&(config_info.input_type), goodix_ts_irq_handler,irq_table[ts->int_trigger_type], ts);	   
     if (ret) {
             printk("Request irq fail!.\n");
     }


### PR DESCRIPTION
使用Goodix宏定义去配置中断出发方式.
不需要在两个地方去配置